### PR TITLE
Ordena semanas numericamente em carregamento de vendas

### DIFF
--- a/projecao.ipynb
+++ b/projecao.ipynb
@@ -85,6 +85,7 @@
     "            rename_map[col] = f\"W{semana}_{ano}\" # \"Crie o novo nome no formato WXX_YY\", Exemplo: \"W34_25\"\n",
     "    \n",
     "    df = df.rename(columns=rename_map)\n",
+    "# Ordena semanas numericamente\n",
     "    def sort_key(w):\n",
     "        sem, ano = w.split('_')\n",
     "        return int(ano), int(sem[1:])\n",


### PR DESCRIPTION
## Summary
- documenta ordenação numérica de semanas na função `carregar_vendas`

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68aca6573354833199804b69a8ec303f