### PR TITLE
Add estoque loading function

### DIFF
--- a/projecao.ipynb
+++ b/projecao.ipynb
@@ -102,10 +102,29 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "85c0d106",
+   "id": "378cc349",
    "metadata": {},
    "outputs": [],
-   "source": []
+   "source": [
+    "# ==================================================\n",
+    "# 2. FUNÇÃO: CARREGAR ESTOQUE\n",
+    "# ==================================================\n",
+    "def carregar_estoque(caminho_arquivo):\n",
+    "    \"\"\"Carrega e processa arquivo de estoque de franquias por Artigo-Cor\"\"\"\n",
+    "    print(\"📦 Carregando estoque de franquias por Artigo-Cor...\")\n",
+    "    df = pd.read_excel(caminho_arquivo, engine='openpyxl')\n",
+    "    df.columns = df.columns.str.strip()\n",
+    "    print(\"📋 Colunas no estoque:\", df.columns.tolist())\n",
+    "    \n",
+    "    df[\"FILIAL\"] = pd.to_numeric(df[\"FILIAL\"], errors=\"coerce\").fillna(0).astype(int)\n",
+    "    df[\"ArtigoCor\"] = df[\"ArtigoCor\"].astype(str).str.upper().str.strip()\n",
+    "    df = df.rename(columns={\"Estoque Semanal Total\": \"ESTOQUE_INICIAL\"})\n",
+    "    \n",
+    "    df = df[[\"FILIAL\", \"ArtigoCor\", \"ESTOQUE_INICIAL\"]]\n",
+    "    print(f\"✅ Estoque: {len(df)} Artigos-Cor de franquias\")\n",
+    "    print(\"📋 Colunas após processamento:\", df.columns.tolist())\n",
+    "    return df\n"
+   ]
   },
   {
    "cell_type": "code",


### PR DESCRIPTION
## Summary
- implement `carregar_estoque` to load and normalize stock data for franchises

## Testing
- `python - <<'PY'
import nbformat, pandas as pd
nb = nbformat.read(open('projecao.ipynb'), as_version=4)
env = {}
exec(nb['cells'][2]['source'], env)
exec(nb['cells'][4]['source'], env)
import pandas as pd
pd.DataFrame({'FILIAL':[1], 'ArtigoCor':['produto'], 'Estoque Semanal Total':[20]}).to_excel('dummy.xlsx', index=False)
res = env['carregar_estoque']('dummy.xlsx')
print(res)
PY`


------
https://chatgpt.com/codex/tasks/task_e_68ad0051a5008331b2c45141137feefb